### PR TITLE
[fix] More build error.

### DIFF
--- a/hironx_rpc_msgs/package.xml
+++ b/hironx_rpc_msgs/package.xml
@@ -18,6 +18,7 @@
   <depend>actionlib_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>tork_rpc_util</depend>
   <exec_depend>message_runtime</exec_depend>
   <export />
 </package>


### PR DESCRIPTION
In ROS Prerelease Test the following occurred, which indicate catkin couldn't find the package in the message.

```
-- Using these message generators: gencpp;genlisp;genpy
CMake Warning at /opt/ros/indigo/share/catkin/cmake/catkinConfig.cmake:76 (find_package):
  Could not find a package configuration file provided by "tork_rpc_util"
  with any of the following names:

    tork_rpc_utilConfig.cmake
    tork_rpc_util-config.cmake

  Add the installation prefix of "tork_rpc_util" to CMAKE_PREFIX_PATH or set
  "tork_rpc_util_DIR" to a directory containing one of the above files.  If
  "tork_rpc_util" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)

-- Could not find the required component 'tork_rpc_util'. The following CMake error indicates that you either need to install the package with the same name or change your environment so that it can be found.
CMake Error at /opt/ros/indigo/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
  Could not find a package configuration file provided by "tork_rpc_util"
  with any of the following names:

    tork_rpc_utilConfig.cmake
    tork_rpc_util-config.cmake

  Add the installation prefix of "tork_rpc_util" to CMAKE_PREFIX_PATH or set
  "tork_rpc_util_DIR" to a directory containing one of the above files.  If
  "tork_rpc_util" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)
```